### PR TITLE
Add composer.lock to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM base AS build
 
 # Now install dev dependencies
 COPY composer.json /app/
+COPY composer.lock /app/
 RUN composer install
 
 FROM build AS unit-test


### PR DESCRIPTION
This makes the Dockerfile a bit more production-ready by also copying the lock file before running composer install, to ensure what is built is what you expect.